### PR TITLE
tests/gen-tests-mk: fix random size aspect ratio generation

### DIFF
--- a/tests/gen-tests-mk
+++ b/tests/gen-tests-mk
@@ -101,8 +101,11 @@ def generate_resolutions (resolution_icdf, resolution_min, resolution_max, num_s
   # Generate 2D resolutions based on the resolution areas and aspect ratio range
   resolutions2d = []
   for reso in generated_resolutions:
-    randreso = np.random.randint (round (reso * min_ratio), round (reso * max_ratio) + 1)
-    resolutions2d.append ((randreso, round (reso * reso / randreso)))
+    total_pixels = reso * reso
+    ratio = random.uniform (min_ratio, max_ratio)
+    width  = int (round (np.sqrt (total_pixels * ratio)))
+    height = int (round (np.sqrt (total_pixels / ratio)))
+    resolutions2d.append ((width, height))
   return resolutions2d # generated_resolutions
 
 def symlink (target, link):

--- a/tests/gen-tests-mk
+++ b/tests/gen-tests-mk
@@ -103,8 +103,8 @@ def generate_resolutions (resolution_icdf, resolution_min, resolution_max, num_s
   for reso in generated_resolutions:
     total_pixels = reso * reso
     ratio = random.uniform (min_ratio, max_ratio)
-    width  = int (round (np.sqrt (total_pixels * ratio)))
-    height = int (round (np.sqrt (total_pixels / ratio)))
+    width  = round (np.sqrt (total_pixels * ratio))
+    height = round (np.sqrt (total_pixels / ratio))
     resolutions2d.append ((width, height))
   return resolutions2d # generated_resolutions
 


### PR DESCRIPTION
I've seen that the aspect ratio of the j90randomsizej80 test is not correct. randomsize.inc contains as extremes (with ~1000 images):

281x891
1274x403

which are both not in 16:9...9:16. With the fix applied, the extremes are

358x634
1335x752

which are what I'd expect it to be.