### PR TITLE
src: drop unused scipy.misc imports, unbreak scipy>=1.12

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -1,6 +1,6 @@
 # Licensed under the GNU GPL-3.0+: https://www.gnu.org/licenses/gpl-3.0.html
 import numpy as np
-import scipy.misc, scipy.signal, cv2
+import scipy.signal, cv2
 import os, sys
 import math, config
 from config import eprint, vprint, dprint, verbose

--- a/src/embed.py
+++ b/src/embed.py
@@ -1,7 +1,7 @@
 # Licensed under the GNU GPL-3.0+: https://www.gnu.org/licenses/gpl-3.0.html
 import argparse
 import numpy as np
-import scipy.misc, scipy.signal, cv2
+import scipy.signal, cv2
 import sys
 from plotting import *
 import config, common

--- a/src/extract.py
+++ b/src/extract.py
@@ -8,7 +8,7 @@ from config import vprint, dprint, eprint
 import math
 from plotting import *
 from ddist import distribution_divergence
-import scipy.misc, scipy.signal, cv2
+import scipy.signal, cv2
 import skimage.color
 import imageio
 import subprocess

--- a/src/imagewmark.py
+++ b/src/imagewmark.py
@@ -16,7 +16,7 @@ __version__ = open (str (BASE_DIR / "../.version")).read().strip()
 import argparse
 import embed, extract
 import numpy as np
-import scipy.misc, scipy.signal, cv2
+import scipy.signal, cv2
 import hashlib
 from plotting import *
 import config, common


### PR DESCRIPTION
## Summary

- Remove `import scipy.misc` from `src/common.py`, `src/embed.py`, `src/extract.py` and `src/imagewmark.py`. Nothing in the codebase uses anything from `scipy.misc`, but the import alone crashes on SciPy >= 1.12.0, where the submodule was removed (scipy/scipy#15608).
- With these dead imports gone, imagewmark builds and runs against current NumPy 2.x and SciPy releases, which also addresses the `numpy.core.multiarray failed to import` class of startup failures seen when mixing NumPy 2 with SciPy builds for NumPy 1.x (issue #18).

## Testing

Embed/get roundtrip (`cafe` watermark, 512x512 image), identical results on both stacks:

| Stack | Result |
|---|---|
| numpy 1.26.4 / scipy 1.11.4 / cv2 4.x | PSNR 41.943, `cafe` detected JSD 100%/99.4% |
| numpy 2.5.2 / scipy 1.18.1 / cv2 5.0 | PSNR 41.943, `cafe` detected JSD 100%/99.4% |

Refs #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal image-processing imports to remove deprecated and unused dependencies.
  - Existing image-processing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->